### PR TITLE
Added fallback for capturing on KDE Wayland

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -82,6 +82,22 @@ jobs:
           projectPath: app
           tauriScript: cargo tauri
 
+      # Ubuntu's libpipewire hardcodes Debian's SPA plugin directory
+      # (/usr/lib/x86_64-linux-gnu/spa-0.2); bundled into the AppImage it
+      # cannot load its plugins on any non-Debian distro and portal screen
+      # capture dies with "Creation failed". Strip it so the host's own
+      # libpipewire (which knows its own plugin paths) is loaded instead.
+      - name: Strip bundled libpipewire and repack AppImage
+        run: |
+          set -euo pipefail
+          appdir=target/release/bundle/appimage/BARAS.AppDir
+          appimage=$(ls target/release/bundle/appimage/*.AppImage)
+          rm -f "$appdir"/usr/lib/libpipewire-0.3.so*
+          wget -q -O /tmp/appimagetool \
+            https://github.com/AppImage/appimagetool/releases/download/continuous/appimagetool-x86_64.AppImage
+          chmod +x /tmp/appimagetool
+          ARCH=x86_64 /tmp/appimagetool "$appdir" "$appimage"
+
       - name: Upload Linux artifacts
         uses: actions/upload-artifact@v4
         with:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -40,6 +40,7 @@ jobs:
             librsvg2-dev \
             patchelf \
             libxdo-dev \
+            libpipewire-0.3-dev \
             libasound2-dev
 
       - name: Setup Rust

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -34,6 +34,7 @@ jobs:
             librsvg2-dev \
             patchelf \
             libxdo-dev \
+            libpipewire-0.3-dev \
             libasound2-dev
 
       - name: Setup Rust

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -91,6 +91,34 @@ jobs:
           releaseDraft: false
           prerelease: false
 
+      # Ubuntu's libpipewire hardcodes Debian's SPA plugin directory
+      # (/usr/lib/x86_64-linux-gnu/spa-0.2); bundled into the AppImage it
+      # cannot load its plugins on any non-Debian distro and portal screen
+      # capture dies with "Creation failed". Strip it so the host's own
+      # libpipewire (which knows its own plugin paths) is loaded instead,
+      # then re-sign (the updater checks the .sig against the repacked
+      # bytes) and replace the release assets.
+      - name: Strip bundled libpipewire, repack, re-sign and re-upload AppImage
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          TAURI_SIGNING_PRIVATE_KEY: ${{ secrets.TAURI_SIGNING_PRIVATE_KEY }}
+          TAURI_SIGNING_PRIVATE_KEY_PASSWORD: ${{ secrets.TAURI_SIGNING_PRIVATE_KEY_PASSWORD }}
+        run: |
+          set -euo pipefail
+          appdir=target/release/bundle/appimage/BARAS.AppDir
+          appimage=$(ls target/release/bundle/appimage/*.AppImage)
+          rm -f "$appdir"/usr/lib/libpipewire-0.3.so*
+          wget -q -O /tmp/appimagetool \
+            https://github.com/AppImage/appimagetool/releases/download/continuous/appimagetool-x86_64.AppImage
+          chmod +x /tmp/appimagetool
+          ARCH=x86_64 /tmp/appimagetool "$appdir" "$appimage"
+          cargo tauri signer sign \
+            --private-key "$TAURI_SIGNING_PRIVATE_KEY" \
+            --password "$TAURI_SIGNING_PRIVATE_KEY_PASSWORD" \
+            "$appimage"
+          gh release upload "v${{ steps.version.outputs.version }}" \
+            "$appimage" "$appimage.sig" --clobber
+
   build-windows:
     runs-on: windows-latest
     permissions:

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -84,6 +84,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "annotate-snippets"
+version = "0.11.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "710e8eae58854cdc1790fcb56cca04d712a17be849eeb81da2a724bf4bae2bc4"
+dependencies = [
+ "anstyle",
+ "unicode-width",
+]
+
+[[package]]
 name = "anstream"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -650,7 +660,7 @@ dependencies = [
  "glib-sys",
  "gobject-sys",
  "libc",
- "system-deps",
+ "system-deps 6.2.2",
 ]
 
 [[package]]
@@ -766,16 +776,19 @@ dependencies = [
 name = "baras-overlay"
 version = "0.1.0"
 dependencies = [
+ "ashpd",
  "baras-core",
  "baras-types",
  "core-graphics",
  "cosmic-text",
+ "dirs",
  "dispatch",
  "fontdb",
  "memmap2",
  "objc2",
  "objc2-app-kit",
  "objc2-foundation",
+ "pipewire",
  "png 0.17.16",
  "rustix",
  "swash",
@@ -885,6 +898,7 @@ version = "0.72.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "993776b509cfb49c750f11b8f07a46fa23e0a1386ffc01fb1e7d343efc387895"
 dependencies = [
+ "annotate-snippets",
  "bitflags 2.13.0",
  "cexpr",
  "clang-sys",
@@ -1059,7 +1073,7 @@ checksum = "685c9fa8e590b8b3d678873528d83411db17242a73fccaed827770ea0fedda51"
 dependencies = [
  "glib-sys",
  "libc",
- "system-deps",
+ "system-deps 6.2.2",
 ]
 
 [[package]]
@@ -1128,7 +1142,7 @@ version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6fac387a98bb7c37292057cffc56d62ecb629900026402633ae9160df93a8766"
 dependencies = [
- "nom",
+ "nom 7.1.3",
 ]
 
 [[package]]
@@ -1149,7 +1163,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d067ad48b8650848b989a59a86c6c36a995d02d2bf778d45c3c5d57bc2718f02"
 dependencies = [
  "smallvec",
- "target-lexicon",
+ "target-lexicon 0.12.16",
+]
+
+[[package]]
+name = "cfg-expr"
+version = "0.20.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fe4ece8474b5f766c63426647e7b4b316b67431ade1036a8313cee24a03ae917"
+dependencies = [
+ "smallvec",
+ "target-lexicon 0.13.5",
 ]
 
 [[package]]
@@ -1464,6 +1488,12 @@ dependencies = [
  "time",
  "version_check",
 ]
+
+[[package]]
+name = "cookie-factory"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9885fa71e26b8ab7855e2ec7cae6e9b380edff76cd052e07c683a0319d51b3a2"
 
 [[package]]
 name = "cookie_store"
@@ -3655,7 +3685,7 @@ dependencies = [
  "glib-sys",
  "gobject-sys",
  "libc",
- "system-deps",
+ "system-deps 6.2.2",
 ]
 
 [[package]]
@@ -3672,7 +3702,7 @@ dependencies = [
  "libc",
  "pango-sys",
  "pkg-config",
- "system-deps",
+ "system-deps 6.2.2",
 ]
 
 [[package]]
@@ -3686,7 +3716,7 @@ dependencies = [
  "gobject-sys",
  "libc",
  "pkg-config",
- "system-deps",
+ "system-deps 6.2.2",
 ]
 
 [[package]]
@@ -3712,7 +3742,7 @@ dependencies = [
  "gdk-sys",
  "glib-sys",
  "libc",
- "system-deps",
+ "system-deps 6.2.2",
  "x11",
 ]
 
@@ -3825,7 +3855,7 @@ dependencies = [
  "glib-sys",
  "gobject-sys",
  "libc",
- "system-deps",
+ "system-deps 6.2.2",
  "winapi",
 ]
 
@@ -3873,7 +3903,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "063ce2eb6a8d0ea93d2bf8ba1957e78dbab6be1c2220dd3daca57d5a9d869898"
 dependencies = [
  "libc",
- "system-deps",
+ "system-deps 6.2.2",
 ]
 
 [[package]]
@@ -3966,7 +3996,7 @@ checksum = "0850127b514d1c4a4654ead6dedadb18198999985908e6ffe4436f53c785ce44"
 dependencies = [
  "glib-sys",
  "libc",
- "system-deps",
+ "system-deps 6.2.2",
 ]
 
 [[package]]
@@ -4005,7 +4035,7 @@ dependencies = [
  "gobject-sys",
  "libc",
  "pango-sys",
- "system-deps",
+ "system-deps 6.2.2",
 ]
 
 [[package]]
@@ -4614,7 +4644,7 @@ dependencies = [
  "glib-sys",
  "gobject-sys",
  "libc",
- "system-deps",
+ "system-deps 6.2.2",
 ]
 
 [[package]]
@@ -4948,6 +4978,33 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f02ab6bace2054fb888a3c16f990117b579d14a3088e472d63c6011fa185c9d3"
 dependencies = [
  "libc",
+]
+
+[[package]]
+name = "libspa"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "882f7427e7989dcc9d388b7f05c4630390a1d7696f9ffa469cd4a7a48f0b4c40"
+dependencies = [
+ "bitflags 2.13.0",
+ "cc",
+ "cookie-factory",
+ "libc",
+ "libspa-sys",
+ "nom 8.0.0",
+ "rustix",
+ "system-deps 7.0.8",
+]
+
+[[package]]
+name = "libspa-sys"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3b6e17bdaf63ed0d5e4144022624032b41fd9733112e8c74ac26fc9bf1291924"
+dependencies = [
+ "bindgen",
+ "cc",
+ "system-deps 7.0.8",
 ]
 
 [[package]]
@@ -5314,6 +5371,15 @@ checksum = "d273983c5a657a70a3e8f2a01329822f3b8c8172b73826411a55751e404a0a4a"
 dependencies = [
  "memchr",
  "minimal-lexical",
+]
+
+[[package]]
+name = "nom"
+version = "8.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "df9761775871bdef83bee530e60050f7e54b1105350d6884eb0fb4f46c2f9405"
+dependencies = [
+ "memchr",
 ]
 
 [[package]]
@@ -5876,7 +5942,7 @@ dependencies = [
  "glib-sys",
  "gobject-sys",
  "libc",
- "system-deps",
+ "system-deps 6.2.2",
 ]
 
 [[package]]
@@ -6080,6 +6146,31 @@ dependencies = [
  "atomic-waker",
  "fastrand",
  "futures-io",
+]
+
+[[package]]
+name = "pipewire"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bde71084c4e25959d68f1ea54daa75e5ecdb338e5caf0b5510143b79baa32d5c"
+dependencies = [
+ "bitflags 2.13.0",
+ "libc",
+ "libspa",
+ "libspa-sys",
+ "pipewire-sys",
+ "rustix",
+]
+
+[[package]]
+name = "pipewire-sys"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9ce653f53e63e5b93853218092ee9a8906a5d082c92f3f1db26316955dd63ce0"
+dependencies = [
+ "bindgen",
+ "libspa-sys",
+ "system-deps 7.0.8",
 ]
 
 [[package]]
@@ -7478,7 +7569,7 @@ dependencies = [
  "glib-sys",
  "gobject-sys",
  "libc",
- "system-deps",
+ "system-deps 6.2.2",
 ]
 
 [[package]]
@@ -7758,10 +7849,23 @@ version = "6.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a3e535eb8dded36d55ec13eddacd30dec501792ff23a0b1682c38601b8cf2349"
 dependencies = [
- "cfg-expr",
+ "cfg-expr 0.15.8",
  "heck 0.5.0",
  "pkg-config",
  "toml 0.8.2",
+ "version-compare",
+]
+
+[[package]]
+name = "system-deps"
+version = "7.0.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "396a35feb67335377e0251fcbc1092fc85c484bd4e3a7a54319399da127796e7"
+dependencies = [
+ "cfg-expr 0.20.9",
+ "heck 0.5.0",
+ "pkg-config",
+ "toml 1.1.2+spec-1.1.0",
  "version-compare",
 ]
 
@@ -7832,6 +7936,12 @@ name = "target-lexicon"
 version = "0.12.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "61c41af27dd6d1e27b1b16b489db798443478cef1f06a660c96db617ba5de3b1"
+
+[[package]]
+name = "target-lexicon"
+version = "0.13.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "adb6935a6f5c20170eeceb1a3835a49e12e19d792f6dd344ccc76a985ca5a6ca"
 
 [[package]]
 name = "tauri"
@@ -9360,7 +9470,7 @@ dependencies = [
  "libc",
  "pkg-config",
  "soup3-sys",
- "system-deps",
+ "system-deps 6.2.2",
 ]
 
 [[package]]

--- a/app/assets/styles.css
+++ b/app/assets/styles.css
@@ -3594,6 +3594,62 @@ details[open] .collapsible-summary::before {
   box-shadow: 0 4px 12px rgba(255, 215, 0, 0.3);
 }
 
+.screen-capture-modal {
+  max-width: 560px;
+}
+
+.screen-capture-header h3,
+.screen-capture-header h3 i {
+  color: var(--swtor-blue);
+}
+
+.screen-capture-content {
+  padding: 1.25em;
+  color: var(--text-secondary);
+  line-height: 1.5;
+}
+
+.screen-capture-content p:first-child {
+  margin-top: 0;
+  color: var(--text-primary);
+}
+
+.screen-capture-note {
+  display: flex;
+  gap: 0.75em;
+  margin-top: 1em;
+  padding: 0.9em;
+  background: var(--blue-alpha-10);
+  border: 1px solid var(--blue-alpha-20);
+  border-radius: var(--radius-md);
+}
+
+.screen-capture-note i {
+  color: var(--swtor-blue);
+}
+
+.screen-capture-note div,
+.screen-capture-note span {
+  display: block;
+}
+
+.screen-capture-note strong {
+  color: var(--text-primary);
+}
+
+.screen-capture-error {
+  margin-top: 1em;
+  color: var(--color-error);
+}
+
+.screen-capture-footer {
+  display: flex;
+  justify-content: flex-end;
+  gap: 0.75em;
+  padding: 1em 1.25em;
+  border-top: 1px solid var(--blue-alpha-15);
+}
+
 /* ─────────────────────────────────────────────────────────────────────────────
    Contributors Modal
    ───────────────────────────────────────────────────────────────────────────── */

--- a/app/src-tauri/src/commands/overlay.rs
+++ b/app/src-tauri/src/commands/overlay.rs
@@ -60,6 +60,25 @@ pub struct OverlayStatusResponse {
     pub auto_hidden: bool,
 }
 
+#[tauri::command]
+pub async fn prepare_screen_capture() -> bool {
+    if !baras_overlay::capture::portal_required() {
+        return false;
+    }
+    if !baras_overlay::capture::has_portal_restore_token() {
+        tracing::info!(target: "baras::capture", "screen capture permission required");
+        return true;
+    }
+    baras_overlay::capture::enable_portal().await.is_err()
+}
+
+#[tauri::command]
+pub async fn enable_screen_capture() -> Result<(), String> {
+    baras_overlay::capture::enable_portal()
+        .await
+        .map_err(|e| e.to_string())
+}
+
 // ─────────────────────────────────────────────────────────────────────────────
 // Show/Hide Commands
 // ─────────────────────────────────────────────────────────────────────────────

--- a/app/src-tauri/src/lib.rs
+++ b/app/src-tauri/src/lib.rs
@@ -249,6 +249,8 @@ pub fn run() {
             commands::start_operation_timer,
             commands::stop_operation_timer,
             commands::reset_operation_timer,
+            commands::prepare_screen_capture,
+            commands::enable_screen_capture,
             // Service commands
             commands::get_log_files,
             commands::start_tailing,

--- a/app/src-tauri/src/router.rs
+++ b/app/src-tauri/src/router.rs
@@ -12,6 +12,7 @@ use crate::overlay::{
 use crate::service::{OverlayUpdate, ServiceHandle};
 use crate::state::SharedState;
 use baras_overlay::{OverlayData, RaidRegistryAction};
+use tauri::{Emitter, Manager};
 use tokio::sync::{Semaphore, mpsc};
 
 /// Spawn the overlay update router task.
@@ -101,6 +102,16 @@ async fn process_registry_action(
         }
         RaidRegistryAction::ClearAll => {
             service_handle.clear_raid_registry().await;
+        }
+        RaidRegistryAction::CapturePermissionRequired => {
+            if let Some(window) = service_handle.app_handle.get_webview_window("main") {
+                let _ = window.show();
+                let _ = window.unminimize();
+                let _ = window.set_focus();
+            }
+            let _ = service_handle
+                .app_handle
+                .emit("screen-capture-permission-required", ());
         }
         RaidRegistryAction::DetectNames {
             started_at,

--- a/app/src/api.rs
+++ b/app/src/api.rs
@@ -104,6 +104,16 @@ pub async fn is_wayland_session() -> bool {
     from_js(result).unwrap_or(false)
 }
 
+pub async fn prepare_screen_capture() -> bool {
+    let result = invoke("prepare_screen_capture", JsValue::NULL).await;
+    from_js(result).unwrap_or(false)
+}
+
+pub async fn enable_screen_capture() -> Result<(), String> {
+    try_invoke("enable_screen_capture", JsValue::NULL).await?;
+    Ok(())
+}
+
 // ─────────────────────────────────────────────────────────────────────────────
 // Overlay Commands
 // ─────────────────────────────────────────────────────────────────────────────

--- a/app/src/app.rs
+++ b/app/src/app.rs
@@ -151,6 +151,15 @@ pub fn App() -> Element {
     let mut changelog_open = use_signal(|| false);
     let mut changelog_html = use_signal(String::new);
     let mut contributors_open = use_signal(|| false);
+    let mut screen_capture_permission_open = use_signal(|| false);
+    let mut screen_capture_starting = use_signal(|| false);
+    let mut screen_capture_error = use_signal(|| None::<String>);
+
+    use_future(move || async move {
+        if api::prepare_screen_capture().await {
+            screen_capture_permission_open.set(true);
+        }
+    });
 
     // Audio settings
     let mut audio_enabled = use_signal(|| true);
@@ -287,6 +296,17 @@ pub fn App() -> Element {
             }
         });
         api::tauri_listen("active-file-changed", &closure).await;
+        closure.forget();
+    });
+
+    use_future(move || async move {
+        let closure = Closure::new(move |_event: JsValue| {
+            let _ = screen_capture_error.try_write().map(|mut value| *value = None);
+            let _ = screen_capture_permission_open
+                .try_write()
+                .map(|mut value| *value = true);
+        });
+        api::tauri_listen("screen-capture-permission-required", &closure).await;
         closure.forget();
     });
 
@@ -2781,6 +2801,72 @@ pub fn App() -> Element {
                                     });
                                 },
                                 "Got it!"
+                            }
+                        }
+                    }
+                }
+            }
+
+            if screen_capture_permission_open() {
+                div {
+                    class: "modal-backdrop",
+                    div {
+                        class: "changelog-modal screen-capture-modal",
+                        onclick: move |e| e.stop_propagation(),
+                        div { class: "changelog-header screen-capture-header",
+                            h3 {
+                                i { class: "fa-solid fa-display" }
+                                " Screen capture permission"
+                            }
+                            button {
+                                class: "btn btn-close",
+                                disabled: screen_capture_starting(),
+                                onclick: move |_| screen_capture_permission_open.set(false),
+                                "X"
+                            }
+                        }
+                        div { class: "screen-capture-content",
+                            p { "BARAS needs access to your screen to detect raid-frame names." }
+                            p {
+                                "Your desktop doesn't support BARAS's direct capture method. KDE will ask you to choose the monitor where SWTOR is running."
+                            }
+                            div { class: "screen-capture-note",
+                                i { class: "fa-solid fa-shield-halved" }
+                                div {
+                                    strong { "What BARAS captures" }
+                                    span { "Only the configured raid-frame area is processed for OCR. Debug captures are saved only when OCR debug dumps are enabled." }
+                                }
+                            }
+                            if let Some(error) = screen_capture_error() {
+                                div { class: "screen-capture-error", "{error}" }
+                            }
+                        }
+                        div { class: "screen-capture-footer",
+                            button {
+                                class: "btn btn-secondary",
+                                disabled: screen_capture_starting(),
+                                onclick: move |_| screen_capture_permission_open.set(false),
+                                "Not now"
+                            }
+                            button {
+                                class: "btn btn-primary",
+                                disabled: screen_capture_starting(),
+                                onclick: move |_| {
+                                    screen_capture_starting.set(true);
+                                    screen_capture_error.set(None);
+                                    spawn(async move {
+                                        match api::enable_screen_capture().await {
+                                            Ok(()) => screen_capture_permission_open.set(false),
+                                            Err(error) if error.to_lowercase().contains("declined") => {
+                                                screen_capture_permission_open.set(false);
+                                            }
+                                            Err(error) => screen_capture_error.set(Some(error)),
+                                        }
+                                        screen_capture_starting.set(false);
+                                    });
+                                },
+                                i { class: "fa-solid fa-display" }
+                                if screen_capture_starting() { " Waiting..." } else { " Choose monitor" }
                             }
                         }
                     }

--- a/app/src/app.rs
+++ b/app/src/app.rs
@@ -2853,7 +2853,7 @@ pub fn App() -> Element {
                         div { class: "screen-capture-content",
                             p { "BARAS needs access to your screen to detect raid-frame names." }
                             p {
-                                "Your desktop doesn't support BARAS's direct capture method. KDE will ask you to choose the monitor where SWTOR is running."
+                                "Your desktop doesn't support BARAS's direct capture method. You will be asked to choose the monitor where SWTOR is running."
                             }
                             div { class: "screen-capture-note",
                                 i { class: "fa-solid fa-shield-halved" }

--- a/overlay/Cargo.toml
+++ b/overlay/Cargo.toml
@@ -43,6 +43,11 @@ rustix = { version = "1.0", features = ["fs", "mm"] }
 # Platform: X11 (Linux fallback)
 x11rb = { version = "0.13", features = ["randr", "shape", "shm"] }
 
+[target.'cfg(target_os = "linux")'.dependencies]
+ashpd = { version = "0.12", default-features = false, features = ["tokio"] }
+pipewire = "0.10.1"
+dirs = "6"
+
 # Platform: Windows
 [target.'cfg(target_os = "windows")'.dependencies]
 windows = { version = "0.62", features = [

--- a/overlay/src/capture/mod.rs
+++ b/overlay/src/capture/mod.rs
@@ -16,6 +16,18 @@ use unix as backend;
 /// callers can hide detection UI rather than fail at press time.
 pub const SUPPORTED: bool = cfg!(any(target_os = "windows", all(unix, not(target_os = "macos"))));
 
+fn log_backend(backend: &str, direct_supported: bool) {
+    static LOGGED: std::sync::Once = std::sync::Once::new();
+    LOGGED.call_once(|| {
+        tracing::info!(
+            target: "baras::capture",
+            backend,
+            direct_supported,
+            "screen capture backend selected"
+        );
+    });
+}
+
 #[cfg(not(any(target_os = "windows", all(unix, not(target_os = "macos")))))]
 mod backend {
     use super::{CaptureError, CapturedImage};
@@ -159,6 +171,8 @@ pub enum CaptureError {
     ConnectionFailed(String),
     /// The platform or compositor does not support region capture.
     Unsupported(String),
+    /// Screen capture needs user approval.
+    PermissionRequired(String),
     /// Requested region is empty or off-screen.
     InvalidRegion(String),
     /// Capture was attempted but produced nothing usable.
@@ -170,10 +184,45 @@ impl std::fmt::Display for CaptureError {
         match self {
             CaptureError::ConnectionFailed(s) => write!(f, "Capture connection failed: {s}"),
             CaptureError::Unsupported(s) => write!(f, "Capture unsupported: {s}"),
+            CaptureError::PermissionRequired(s) => write!(f, "Capture permission required: {s}"),
             CaptureError::InvalidRegion(s) => write!(f, "Invalid capture region: {s}"),
             CaptureError::Failed(s) => write!(f, "Capture failed: {s}"),
         }
     }
+}
+
+#[cfg(target_os = "linux")]
+pub fn portal_required() -> bool {
+    unix::portal_required()
+}
+
+#[cfg(not(target_os = "linux"))]
+pub fn portal_required() -> bool {
+    #[cfg(target_os = "windows")]
+    log_backend("windows-gdi", true);
+    #[cfg(target_os = "macos")]
+    log_backend("none", false);
+    false
+}
+
+#[cfg(target_os = "linux")]
+pub fn has_portal_restore_token() -> bool {
+    unix::has_portal_restore_token()
+}
+
+#[cfg(not(target_os = "linux"))]
+pub fn has_portal_restore_token() -> bool {
+    false
+}
+
+#[cfg(target_os = "linux")]
+pub async fn enable_portal() -> Result<(), CaptureError> {
+    unix::enable_portal().await
+}
+
+#[cfg(not(target_os = "linux"))]
+pub async fn enable_portal() -> Result<(), CaptureError> {
+    Err(CaptureError::Unsupported("screen cast portal is only available on Linux".into()))
 }
 
 impl std::error::Error for CaptureError {}

--- a/overlay/src/capture/unix/mod.rs
+++ b/overlay/src/capture/unix/mod.rs
@@ -2,6 +2,8 @@
 
 mod wayland;
 mod x11;
+#[cfg(target_os = "linux")]
+mod portal;
 
 use super::{CaptureError, CapturedImage, log_timing};
 
@@ -14,10 +16,43 @@ pub fn capture_region(
     // Same test the overlay window uses, so the two can never disagree: an X11
     // GetImage cannot read a Wayland session's surfaces.
     if std::env::var("WAYLAND_DISPLAY").is_ok() {
-        wayland::capture_region(x, y, width, height)
+        match wayland::capture_region(x, y, width, height) {
+            Ok(image) => Ok(image),
+            #[cfg(target_os = "linux")]
+            Err(CaptureError::Unsupported(_)) => portal::capture_region(x, y, width, height),
+            Err(error) => Err(error),
+        }
     } else {
         x11::capture_region(x, y, width, height)
     }
+}
+
+#[cfg(target_os = "linux")]
+pub fn portal_required() -> bool {
+    if std::env::var("WAYLAND_DISPLAY").is_err() {
+        super::log_backend("x11-get-image", true);
+        return false;
+    }
+    let direct_supported = wayland::supported();
+    super::log_backend(
+        if direct_supported {
+            "wayland-ext-image-copy"
+        } else {
+            "pipewire-portal"
+        },
+        direct_supported,
+    );
+    !direct_supported
+}
+
+#[cfg(target_os = "linux")]
+pub fn has_portal_restore_token() -> bool {
+    portal::has_restore_token()
+}
+
+#[cfg(target_os = "linux")]
+pub async fn enable_portal() -> Result<(), CaptureError> {
+    portal::enable().await
 }
 
 /// Map a global logical rectangle onto an output's capture buffer.

--- a/overlay/src/capture/unix/portal.rs
+++ b/overlay/src/capture/unix/portal.rs
@@ -1,0 +1,448 @@
+use std::os::fd::OwnedFd;
+use std::path::PathBuf;
+use std::sync::{Arc, Mutex, OnceLock, mpsc};
+use std::time::{Duration, Instant};
+
+use ashpd::desktop::{
+    PersistMode,
+    screencast::{CursorMode, Screencast, SourceType},
+};
+use pipewire as pw;
+use pw::properties::properties;
+use pw::spa::pod::Pod;
+
+use super::{CaptureError, CapturedImage, device_region, log_timing};
+
+const TIMEOUT: Duration = Duration::from_secs(5);
+
+#[derive(Default)]
+struct PortalState {
+    tx: Option<mpsc::Sender<CaptureRequest>>,
+    starting: bool,
+}
+
+struct CaptureRequest {
+    region: (i32, i32, u32, u32),
+    reply: mpsc::Sender<Result<CapturedImage, CaptureError>>,
+}
+
+struct StreamData {
+    format: pw::spa::param::video::VideoInfoRaw,
+    format_logged: bool,
+    pending: Arc<Mutex<Option<CaptureRequest>>>,
+    origin: (i32, i32),
+    logical: (u32, u32),
+}
+
+static PORTAL: OnceLock<Mutex<PortalState>> = OnceLock::new();
+
+fn state() -> &'static Mutex<PortalState> {
+    PORTAL.get_or_init(|| Mutex::new(PortalState::default()))
+}
+
+fn token_path() -> Option<PathBuf> {
+    dirs::config_dir().map(|path| path.join("baras").join("screen-capture-token"))
+}
+
+pub fn has_restore_token() -> bool {
+    token_path().is_some_and(|path| path.is_file())
+}
+
+pub async fn enable() -> Result<(), CaptureError> {
+    {
+        let mut state = state().lock().unwrap_or_else(|p| p.into_inner());
+        if state.tx.is_some() {
+            return Ok(());
+        }
+        if state.starting {
+            return Err(CaptureError::Failed(
+                "screen capture is already starting".into(),
+            ));
+        }
+        state.starting = true;
+    }
+
+    let result = start_portal().await;
+    let mut state = state().lock().unwrap_or_else(|p| p.into_inner());
+    state.starting = false;
+    match result {
+        Ok(tx) => {
+            state.tx = Some(tx);
+            Ok(())
+        }
+        Err(error) => {
+            if matches!(&error, CaptureError::PermissionRequired(_)) {
+                tracing::info!(target: "baras::capture", "screen capture permission not granted");
+            } else {
+                tracing::warn!(target: "baras::capture", error = %error, "screen capture portal unavailable");
+            }
+            Err(error)
+        }
+    }
+}
+
+async fn start_portal() -> Result<mpsc::Sender<CaptureRequest>, CaptureError> {
+    let portal = Screencast::new()
+        .await
+        .map_err(|e| CaptureError::ConnectionFailed(format!("screen cast portal: {e}")))?;
+    let session = portal
+        .create_session()
+        .await
+        .map_err(|e| CaptureError::Failed(format!("could not create screen cast: {e}")))?;
+    let restore_token = token_path()
+        .and_then(|path| std::fs::read_to_string(path).ok())
+        .map(|token| token.trim().to_owned())
+        .filter(|token| !token.is_empty());
+    tracing::info!(
+        target: "baras::capture",
+        restore_requested = restore_token.is_some(),
+        "opening screen capture portal"
+    );
+
+    portal
+        .select_sources(
+            &session,
+            CursorMode::Hidden,
+            SourceType::Monitor.into(),
+            false,
+            restore_token.as_deref(),
+            PersistMode::ExplicitlyRevoked,
+        )
+        .await
+        .map_err(|e| CaptureError::Failed(format!("could not select a monitor: {e}")))?;
+
+    let response = portal
+        .start(&session, None)
+        .await
+        .map_err(|e| CaptureError::Failed(format!("screen capture request failed: {e}")))?
+        .response()
+        .map_err(|e| {
+            CaptureError::PermissionRequired(format!("screen capture was declined: {e}"))
+        })?;
+    let stream = response
+        .streams()
+        .first()
+        .ok_or_else(|| CaptureError::Failed("the portal returned no monitor".into()))?;
+    let node = stream.pipe_wire_node_id();
+    let origin = stream.position().unwrap_or((0, 0));
+    let logical = stream
+        .size()
+        .and_then(|(w, h)| Some((u32::try_from(w).ok()?, u32::try_from(h).ok()?)))
+        .unwrap_or((0, 0));
+    let new_token = response.restore_token().map(str::to_owned);
+    let fd = portal
+        .open_pipe_wire_remote(&session)
+        .await
+        .map_err(|e| CaptureError::Failed(format!("could not open PipeWire: {e}")))?;
+    let tx = spawn_stream(fd, node, origin, logical)?;
+
+    tracing::info!(
+        target: "baras::capture",
+        backend = "pipewire-portal",
+        node,
+        origin = ?origin,
+        logical_size = ?logical,
+        restore_token = new_token.is_some(),
+        on_demand = true,
+        "screen capture portal ready"
+    );
+
+    if let (Some(path), Some(token)) = (token_path(), new_token) {
+        let saved = path
+            .parent()
+            .map_or(Ok(()), std::fs::create_dir_all)
+            .and_then(|_| std::fs::write(&path, token));
+        if let Err(error) = saved {
+            tracing::warn!(
+                target: "baras::capture",
+                error = %error,
+                "could not save screen capture permission"
+            );
+        }
+    }
+
+    tokio::spawn(async move {
+        let _portal = portal;
+        let _session = session;
+        std::future::pending::<()>().await;
+    });
+    Ok(tx)
+}
+
+pub fn capture_region(
+    x: i32,
+    y: i32,
+    width: u32,
+    height: u32,
+) -> Result<CapturedImage, CaptureError> {
+    let tx = state()
+        .lock()
+        .unwrap_or_else(|p| p.into_inner())
+        .tx
+        .clone()
+        .ok_or_else(|| {
+            CaptureError::PermissionRequired("screen capture permission is required".into())
+        })?;
+    let (reply, result) = mpsc::channel();
+    let started = Instant::now();
+    if tx
+        .send(CaptureRequest {
+            region: (x, y, width, height),
+            reply,
+        })
+        .is_err()
+    {
+        state().lock().unwrap_or_else(|p| p.into_inner()).tx = None;
+        return Err(CaptureError::PermissionRequired(
+            "screen capture session ended".into(),
+        ));
+    }
+    let image = result
+        .recv_timeout(TIMEOUT)
+        .map_err(|_| CaptureError::Failed("PipeWire did not return a frame in time".into()))??;
+    log_timing(
+        "pipewire-portal",
+        Duration::ZERO,
+        started.elapsed(),
+        Duration::ZERO,
+        started.elapsed(),
+        (image.width, image.height),
+    );
+    Ok(image)
+}
+
+fn spawn_stream(
+    fd: OwnedFd,
+    node: u32,
+    origin: (i32, i32),
+    logical: (u32, u32),
+) -> Result<mpsc::Sender<CaptureRequest>, CaptureError> {
+    let (tx, rx) = mpsc::channel();
+    let (ready_tx, ready_rx) = mpsc::sync_channel(1);
+    std::thread::Builder::new()
+        .name("baras-pipewire".into())
+        .spawn(move || {
+            if let Err(error) = run_stream(fd, node, origin, logical, rx, &ready_tx) {
+                let _ = ready_tx.send(Err(error.to_string()));
+                tracing::warn!(target: "baras::capture", error = %error, "PipeWire capture stopped");
+            }
+        })
+        .map_err(|e| CaptureError::Failed(format!("could not start PipeWire: {e}")))?;
+    ready_rx
+        .recv_timeout(TIMEOUT)
+        .map_err(|_| CaptureError::Failed("PipeWire did not start in time".into()))?
+        .map_err(CaptureError::Failed)?;
+    Ok(tx)
+}
+
+fn run_stream(
+    fd: OwnedFd,
+    node: u32,
+    origin: (i32, i32),
+    logical: (u32, u32),
+    requests: mpsc::Receiver<CaptureRequest>,
+    ready: &mpsc::SyncSender<Result<(), String>>,
+) -> Result<(), pw::Error> {
+    let thread_loop = unsafe { pw::thread_loop::ThreadLoopBox::new(Some("baras-pipewire"), None)? };
+    let context = pw::context::ContextBox::new(thread_loop.loop_(), None)?;
+    let core = context.connect_fd(fd, None)?;
+    let pending = Arc::new(Mutex::new(None));
+    let stream = pw::stream::StreamBox::new(
+        &core,
+        "baras-screen-capture",
+        properties! {
+            *pw::keys::MEDIA_TYPE => "Video",
+            *pw::keys::MEDIA_CATEGORY => "Capture",
+            *pw::keys::MEDIA_ROLE => "Screen",
+        },
+    )?;
+    let data = StreamData {
+        format: Default::default(),
+        format_logged: false,
+        pending: pending.clone(),
+        origin,
+        logical,
+    };
+    let _listener = stream
+        .add_local_listener_with_user_data(data)
+        .param_changed(|_, data, id, param| {
+            if id == pw::spa::param::ParamType::Format.as_raw()
+                && let Some(param) = param
+                && data.format.parse(param).is_ok()
+            {
+                if !data.format_logged {
+                    let size = data.format.size();
+                    let frame_mib =
+                        f64::from(size.width) * f64::from(size.height) * 4.0 / (1024.0 * 1024.0);
+                    tracing::info!(
+                        target: "baras::capture",
+                        backend = "pipewire-portal",
+                        format = ?data.format.format(),
+                        width = size.width,
+                        height = size.height,
+                        frame_mib,
+                        "screen capture stream ready"
+                    );
+                    data.format_logged = true;
+                }
+            }
+        })
+        .process(|stream, data| {
+            let Some(request) = data
+                .pending
+                .lock()
+                .unwrap_or_else(|p| p.into_inner())
+                .take()
+            else {
+                let _ = stream.set_active(false);
+                return;
+            };
+            let result = stream
+                .dequeue_buffer()
+                .ok_or_else(|| CaptureError::Failed("PipeWire returned no buffer".into()))
+                .and_then(|mut buffer| {
+                    let pixels = buffer.datas_mut().first_mut().ok_or_else(|| {
+                        CaptureError::Failed("PipeWire returned an empty buffer".into())
+                    })?;
+                    frame_from_buffer(
+                        pixels,
+                        &data.format,
+                        data.origin,
+                        data.logical,
+                        request.region,
+                    )
+                });
+            let _ = stream.set_active(false);
+            let _ = request.reply.send(result);
+        })
+        .register()?;
+
+    let format = pw::spa::pod::object!(
+        pw::spa::utils::SpaTypes::ObjectParamFormat,
+        pw::spa::param::ParamType::EnumFormat,
+        pw::spa::pod::property!(
+            pw::spa::param::format::FormatProperties::MediaType,
+            Id,
+            pw::spa::param::format::MediaType::Video
+        ),
+        pw::spa::pod::property!(
+            pw::spa::param::format::FormatProperties::MediaSubtype,
+            Id,
+            pw::spa::param::format::MediaSubtype::Raw
+        ),
+        pw::spa::pod::property!(
+            pw::spa::param::format::FormatProperties::VideoFormat,
+            Choice,
+            Enum,
+            Id,
+            pw::spa::param::video::VideoFormat::BGRx,
+            pw::spa::param::video::VideoFormat::BGRx,
+            pw::spa::param::video::VideoFormat::BGRA,
+            pw::spa::param::video::VideoFormat::RGBx,
+            pw::spa::param::video::VideoFormat::RGBA,
+        ),
+    );
+    let values = pw::spa::pod::serialize::PodSerializer::serialize(
+        std::io::Cursor::new(Vec::new()),
+        &pw::spa::pod::Value::Object(format),
+    )
+    .map_err(|_| pw::Error::CreationFailed)?
+    .0
+    .into_inner();
+    let mut params = [Pod::from_bytes(&values).ok_or(pw::Error::CreationFailed)?];
+    stream.connect(
+        pw::spa::utils::Direction::Input,
+        Some(node),
+        pw::stream::StreamFlags::AUTOCONNECT
+            | pw::stream::StreamFlags::INACTIVE
+            | pw::stream::StreamFlags::MAP_BUFFERS,
+        &mut params,
+    )?;
+    thread_loop.start();
+    let _ = ready.send(Ok(()));
+
+    for request in requests {
+        let mut slot = pending.lock().unwrap_or_else(|p| p.into_inner());
+        if slot.is_some() {
+            let _ = request.reply.send(Err(CaptureError::Failed(
+                "capture is already running".into(),
+            )));
+            continue;
+        }
+        *slot = Some(request);
+        drop(slot);
+        let _guard = thread_loop.lock();
+        if let Err(error) = stream.set_active(true) {
+            if let Some(request) = pending.lock().unwrap_or_else(|p| p.into_inner()).take() {
+                let _ = request
+                    .reply
+                    .send(Err(CaptureError::Failed(error.to_string())));
+            }
+        }
+    }
+    thread_loop.stop();
+    Ok(())
+}
+
+fn frame_from_buffer(
+    data: &mut pw::spa::buffer::Data,
+    format: &pw::spa::param::video::VideoInfoRaw,
+    origin: (i32, i32),
+    logical: (u32, u32),
+    region: (i32, i32, u32, u32),
+) -> Result<CapturedImage, CaptureError> {
+    let size = format.size();
+    let (width, height) = (size.width, size.height);
+    if width == 0 || height == 0 {
+        return Err(CaptureError::Failed(
+            "PipeWire returned no frame size".into(),
+        ));
+    }
+    let logical = if logical.0 == 0 || logical.1 == 0 {
+        (width, height)
+    } else {
+        logical
+    };
+    let (crop_x, crop_y, crop_width, crop_height) =
+        device_region(region, origin, logical, (width, height)).ok_or_else(|| {
+            CaptureError::InvalidRegion(
+                "the selected monitor does not contain the raid frames".into(),
+            )
+        })?;
+    let offset = data.chunk().offset() as usize;
+    let stride = data.chunk().stride();
+    if stride <= 0 {
+        return Err(CaptureError::Unsupported(
+            "PipeWire returned an unsupported row layout".into(),
+        ));
+    }
+    let stride = stride as usize;
+    let bytes = data
+        .data()
+        .ok_or_else(|| CaptureError::Failed("PipeWire buffer is not mapped".into()))?;
+    let mut rgba = Vec::with_capacity(crop_width as usize * crop_height as usize * 4);
+    let swap = matches!(
+        format.format(),
+        pw::spa::param::video::VideoFormat::BGRx | pw::spa::param::video::VideoFormat::BGRA
+    );
+    for row in crop_y..crop_y + crop_height {
+        let start = offset + row as usize * stride + crop_x as usize * 4;
+        let end = start + crop_width as usize * 4;
+        let pixels = bytes
+            .get(start..end)
+            .ok_or_else(|| CaptureError::Failed("PipeWire returned a short frame".into()))?;
+        for pixel in pixels.chunks_exact(4) {
+            let (r, b) = if swap {
+                (pixel[2], pixel[0])
+            } else {
+                (pixel[0], pixel[2])
+            };
+            rgba.extend_from_slice(&[r, pixel[1], b, 255]);
+        }
+    }
+    Ok(CapturedImage {
+        width: crop_width,
+        height: crop_height,
+        rgba,
+    })
+}

--- a/overlay/src/capture/unix/portal.rs
+++ b/overlay/src/capture/unix/portal.rs
@@ -243,6 +243,8 @@ fn run_stream(
     requests: mpsc::Receiver<CaptureRequest>,
     ready: &mpsc::SyncSender<Result<(), String>>,
 ) -> Result<(), pw::Error> {
+    // Safe to call more than once; the library refuses to work without it.
+    pw::init();
     let thread_loop = unsafe { pw::thread_loop::ThreadLoopBox::new(Some("baras-pipewire"), None)? };
     let context = pw::context::ContextBox::new(thread_loop.loop_(), None)?;
     let core = context.connect_fd(fd, None)?;
@@ -288,6 +290,33 @@ fn run_stream(
             }
         })
         .process(|stream, data| {
+            if data
+                .pending
+                .lock()
+                .unwrap_or_else(|p| p.into_inner())
+                .is_none()
+            {
+                let _ = stream.set_active(false);
+                return;
+            }
+            let Some(mut buffer) = stream.dequeue_buffer() else {
+                // Spurious wakeup; stay active until a buffer arrives.
+                return;
+            };
+            // KWin wakes consumers with cursor-metadata buffers carrying no
+            // pixels (chunk size 0) even when the cursor is hidden. Skip them
+            // and stay active for the next frame; the caller's timeout is the
+            // backstop if none ever comes.
+            let has_pixels = buffer.datas_mut().first().is_some_and(|pixels| {
+                pixels.chunk().size() > 0
+                    && !pixels
+                        .chunk()
+                        .flags()
+                        .contains(pw::spa::buffer::ChunkFlags::CORRUPTED)
+            });
+            if !has_pixels {
+                return;
+            }
             let Some(request) = data
                 .pending
                 .lock()
@@ -297,13 +326,11 @@ fn run_stream(
                 let _ = stream.set_active(false);
                 return;
             };
-            let result = stream
-                .dequeue_buffer()
-                .ok_or_else(|| CaptureError::Failed("PipeWire returned no buffer".into()))
-                .and_then(|mut buffer| {
-                    let pixels = buffer.datas_mut().first_mut().ok_or_else(|| {
-                        CaptureError::Failed("PipeWire returned an empty buffer".into())
-                    })?;
+            let result = buffer
+                .datas_mut()
+                .first_mut()
+                .ok_or_else(|| CaptureError::Failed("PipeWire returned an empty buffer".into()))
+                .and_then(|pixels| {
                     frame_from_buffer(
                         pixels,
                         &data.format,
@@ -410,13 +437,17 @@ fn frame_from_buffer(
             )
         })?;
     let offset = data.chunk().offset() as usize;
-    let stride = data.chunk().stride();
-    if stride <= 0 {
-        return Err(CaptureError::Unsupported(
-            "PipeWire returned an unsupported row layout".into(),
+    // Some producers leave the chunk stride unset; the chunk size still spans
+    // the whole frame, so the row length can be derived from it instead.
+    let stride = match data.chunk().stride() {
+        stride if stride > 0 => stride as usize,
+        _ => data.chunk().size() as usize / height as usize,
+    };
+    if stride < width as usize * 4 {
+        return Err(CaptureError::Failed(
+            "PipeWire returned an unusable row layout".into(),
         ));
     }
-    let stride = stride as usize;
     let bytes = data
         .data()
         .ok_or_else(|| CaptureError::Failed("PipeWire buffer is not mapped".into()))?;

--- a/overlay/src/capture/unix/wayland.rs
+++ b/overlay/src/capture/unix/wayland.rs
@@ -37,6 +37,26 @@ use super::{CaptureError, CapturedImage, device_region};
 /// stopped answering. Without it the overlay thread would hang for good.
 const TIMEOUT: Duration = Duration::from_secs(5);
 
+pub fn supported() -> bool {
+    let Ok(conn) = Connection::connect_to_env() else {
+        return false;
+    };
+    let Ok((globals, _)) = registry_queue_init::<Capture>(&conn) else {
+        return false;
+    };
+    let required = [
+        WlShm::interface().name,
+        ZxdgOutputManagerV1::interface().name,
+        ExtOutputImageCaptureSourceManagerV1::interface().name,
+        ExtImageCopyCaptureManagerV1::interface().name,
+    ];
+    globals.contents().with_list(|list| {
+        required
+            .iter()
+            .all(|name| list.iter().any(|global| global.interface == *name))
+    })
+}
+
 pub fn capture_region(
     x: i32,
     y: i32,
@@ -54,8 +74,7 @@ pub fn capture_region(
 
     let missing = |what: &str| {
         CaptureError::Unsupported(format!(
-            "compositor does not implement {what}; raid-frame capture needs \
-             ext-image-copy-capture-v1 (KWin 6.6+, Mutter 49.2+, Hyprland 0.52.1+, Sway 1.11+)"
+            "compositor does not implement {what}"
         ))
     };
     let shm: WlShm = globals.bind(&qh, 1..=1, ()).map_err(|_| missing("wl_shm"))?;
@@ -198,7 +217,7 @@ pub fn capture_region(
     }
 
     super::log_timing(
-        "wayland",
+        "wayland-ext-image-copy",
         setup,
         captured,
         crop_started.elapsed(),

--- a/overlay/src/capture/unix/x11.rs
+++ b/overlay/src/capture/unix/x11.rs
@@ -72,7 +72,7 @@ pub fn capture_region(
     }
 
     super::log_timing(
-        "x11",
+        "x11-get-image",
         std::time::Duration::ZERO,
         captured,
         converted.elapsed(),

--- a/overlay/src/capture/windows.rs
+++ b/overlay/src/capture/windows.rs
@@ -125,7 +125,7 @@ fn capture_with_dc(
             ))
         } else {
             super::log_timing(
-                "gdi",
+                "windows-gdi",
                 setup,
                 captured,
                 crop_started.elapsed(),

--- a/overlay/src/overlays/mod.rs
+++ b/overlay/src/overlays/mod.rs
@@ -79,6 +79,8 @@ pub enum RaidRegistryAction {
     ClearSlot(u8),
     /// Clear every slot
     ClearAll,
+    /// Ask the app to open screen capture permission.
+    CapturePermissionRequired,
     /// Captured pixels and overlay-local slot rectangles.
     DetectNames {
         started_at: std::time::Instant,

--- a/overlay/src/overlays/raid.rs
+++ b/overlay/src/overlays/raid.rs
@@ -887,9 +887,12 @@ impl RaidOverlay {
             Ok(image) => Some(image),
             Err(e) => {
                 tracing::warn!("Raid frame capture failed: {e}");
-                // An unsupported compositor is permanent: retrying cannot
-                // help, and saying "failed" would invite retries.
                 let message = match e {
+                    crate::capture::CaptureError::PermissionRequired(_) => {
+                        self.pending_registry_actions
+                            .push(RaidRegistryAction::CapturePermissionRequired);
+                        "Screen capture permission required"
+                    }
                     crate::capture::CaptureError::Unsupported(_) => {
                         "Capture not supported by this compositor: assign names manually"
                     }


### PR DESCRIPTION
Uses pipewire + portal.
Will ask for permission on first launch of Baras, if normal capture on Wayland is not supported. Otherwise, nothing changed.
If permission is denied, it will ask again for permission when the capture button is pressed.

Will keep a pipewire stream open, but paused, so no extra CPU/GPU usage, only captures one frame once detection button is pressed.