### PR TITLE
Feature/stream overlay

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -156,6 +156,7 @@ dependencies = [
  "flate2",
  "futures-util",
  "home",
+ "png 0.17.16",
  "pulldown-cmark",
  "reqwest 0.12.28",
  "rodio",

--- a/app/assets/styles.css
+++ b/app/assets/styles.css
@@ -2723,6 +2723,20 @@ details[open] .collapsible-summary::before {
   color: var(--text-secondary);
 }
 
+.web-overlay-url {
+  display: block;
+  margin: 0.5em 0 1em;
+  padding: 0.65em 0.8em;
+  overflow: hidden;
+  color: var(--text-tertiary);
+  background: rgba(0, 0, 0, 0.2);
+  border: 1px solid rgba(255, 255, 255, 0.1);
+  border-radius: var(--radius-md);
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  user-select: all;
+}
+
 /* Directory picker */
 .directory-picker {
   display: flex;

--- a/app/src-tauri/Cargo.toml
+++ b/app/src-tauri/Cargo.toml
@@ -30,7 +30,8 @@ tauri-plugin-global-shortcut = "2"
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 baras-overlay = { path = "../../overlay" }
-tokio = { version = "1.48.0", features = ["sync"] }
+tokio = { version = "1.48.0", features = ["sync", "net", "io-util"] }
+png = "0.17"
 home = "0.5.12"
 dirs = "6.0.0"
 chrono = "0.4.42"

--- a/app/src-tauri/src/commands/mod.rs
+++ b/app/src-tauri/src/commands/mod.rs
@@ -18,6 +18,7 @@ mod overlay;
 mod parsely;
 mod query;
 mod service;
+mod stream_overlay;
 mod url;
 
 // Re-export all commands for the invoke_handler
@@ -27,4 +28,5 @@ pub use overlay::*;
 pub use parsely::*;
 pub use query::*;
 pub use service::*;
+pub use stream_overlay::*;
 pub use url::*;

--- a/app/src-tauri/src/commands/stream_overlay.rs
+++ b/app/src-tauri/src/commands/stream_overlay.rs
@@ -1,0 +1,43 @@
+//! Commands for the generic localhost web overlay.
+
+use baras_types::WEB_OVERLAY_URL;
+use tauri::State;
+
+use crate::overlay::{OverlayCommand, SharedOverlayState};
+use crate::service::ServiceHandle;
+use crate::stream_overlay::WebOverlayServer;
+
+/// Enable or disable the loopback web overlay and persist the setting.
+#[tauri::command]
+pub async fn set_web_overlay_enabled(
+    enabled: bool,
+    server: State<'_, WebOverlayServer>,
+    overlay_state: State<'_, SharedOverlayState>,
+    service: State<'_, ServiceHandle>,
+) -> Result<String, String> {
+    if enabled {
+        server.start().await?;
+
+        // Existing overlays may not render again until their data changes, so
+        // publish their current buffers immediately when the server is enabled.
+        let senders = {
+            let state = overlay_state.lock().map_err(|error| error.to_string())?;
+            state
+                .all_overlays()
+                .into_iter()
+                .map(|(_, sender)| sender.clone())
+                .collect::<Vec<_>>()
+        };
+        for sender in senders {
+            let _ = sender.send(OverlayCommand::CaptureFrame).await;
+        }
+    } else {
+        server.stop().await;
+    }
+
+    let mut config = service.config().await;
+    config.web_overlay_enabled = enabled;
+    service.update_config(config).await?;
+
+    Ok(WEB_OVERLAY_URL.to_string())
+}

--- a/app/src-tauri/src/lib.rs
+++ b/app/src-tauri/src/lib.rs
@@ -18,6 +18,7 @@ pub mod overlay;
 mod router;
 pub mod service;
 pub mod state;
+mod stream_overlay;
 mod tray;
 #[cfg(desktop)]
 mod updater;
@@ -122,6 +123,7 @@ pub fn run() {
 
     // Create shared overlay state
     let overlay_state = Arc::new(Mutex::new(OverlayState::default()));
+    let web_overlay_server = stream_overlay::WebOverlayServer::default();
 
     let mut builder = tauri::Builder::default();
 
@@ -151,6 +153,7 @@ pub fn run() {
         .plugin(tauri_plugin_global_shortcut::Builder::new().build())
         .setup({
             let overlay_state = overlay_state.clone();
+            let web_overlay_server = web_overlay_server.clone();
             move |app| {
                 // Create channel for overlay updates
                 let (overlay_tx, overlay_rx) = mpsc::channel::<OverlayUpdate>(256);
@@ -172,6 +175,20 @@ pub fn run() {
 
                 // Store the service handle for commands
                 app.handle().manage(handle.clone());
+
+                // Restore the optional web overlay server before native
+                // overlays are auto-shown and publish their first frames.
+                {
+                    let service_handle = handle.clone();
+                    let server = web_overlay_server.clone();
+                    tauri::async_runtime::spawn(async move {
+                        if service_handle.config().await.web_overlay_enabled
+                            && let Err(error) = server.start().await
+                        {
+                            tracing::error!(error = %error, "Failed to restore web overlay server");
+                        }
+                    });
+                }
 
                 // Spawn the overlay update router (needs service handle for registry updates)
                 spawn_overlay_router(
@@ -203,6 +220,7 @@ pub fn run() {
             }
         })
         .manage(overlay_state)
+        .manage(web_overlay_server)
         .manage(updater::PendingUpdate::default())
         .on_window_event(|window, event| {
             // Minimize to tray on close instead of quitting (if enabled)
@@ -243,6 +261,7 @@ pub fn run() {
             commands::get_overlay_status,
             commands::refresh_overlay_settings,
             commands::preview_overlay_settings,
+            commands::set_web_overlay_enabled,
             commands::clear_raid_registry,
             commands::swap_raid_slots,
             commands::remove_raid_slot,

--- a/app/src-tauri/src/overlay/spawn.rs
+++ b/app/src-tauri/src/overlay/spawn.rs
@@ -179,11 +179,17 @@ where
                             monitor_y,
                         });
                     }
+                    OverlayCommand::CaptureFrame => {
+                        crate::stream_overlay::capture_overlay(kind, &mut overlay);
+                    }
                     OverlayCommand::DetectRaidNames => {
                         overlay.request_raid_detection();
                         needs_render = true;
                     }
-                    OverlayCommand::Shutdown => return,
+                    OverlayCommand::Shutdown => {
+                        crate::stream_overlay::remove_frame(kind);
+                        return;
+                    }
                 }
             }
 
@@ -225,6 +231,7 @@ where
 
             if needs_render {
                 overlay.render();
+                crate::stream_overlay::capture_overlay(kind, &mut overlay);
                 needs_render = false;
             }
 
@@ -234,6 +241,8 @@ where
             let sleep_ms = if is_interactive { 16 } else { 100 };
             thread::sleep(std::time::Duration::from_millis(sleep_ms));
         }
+
+        crate::stream_overlay::remove_frame(kind);
     });
 
     // Wait for confirmation from the spawned thread
@@ -368,6 +377,12 @@ where
                         });
                         let _ = response_tx.send(event);
                     }
+                    OverlayCommand::CaptureFrame => {
+                        dispatch::Queue::main().exec_sync(move || {
+                            let overlay = unsafe { &mut *overlay_ptr.get() };
+                            crate::stream_overlay::capture_overlay(kind, overlay);
+                        });
+                    }
                     OverlayCommand::DetectRaidNames => {
                         dispatch::Queue::main().exec_sync(move || {
                             let overlay = unsafe { &mut *overlay_ptr.get() };
@@ -376,6 +391,7 @@ where
                         needs_render = true;
                     }
                     OverlayCommand::Shutdown => {
+                        crate::stream_overlay::remove_frame(kind);
                         // Clean up overlay on main thread before returning
                         dispatch::Queue::main().exec_sync(move || {
                             let _ = unsafe { Box::from_raw(overlay_ptr.get()) };
@@ -450,6 +466,7 @@ where
                 dispatch::Queue::main().exec_sync(move || {
                     let overlay = unsafe { &mut *overlay_ptr.get() };
                     overlay.render();
+                    crate::stream_overlay::capture_overlay(kind, overlay);
                 });
                 needs_render = false;
             }
@@ -465,6 +482,7 @@ where
         dispatch::Queue::main().exec_sync(move || {
             let _ = unsafe { Box::from_raw(overlay_ptr.get()) };
         });
+        crate::stream_overlay::remove_frame(kind);
     });
 
     // Wait for confirmation from the spawned thread

--- a/app/src-tauri/src/overlay/state.rs
+++ b/app/src-tauri/src/overlay/state.rs
@@ -32,6 +32,8 @@ pub enum OverlayCommand {
     SetSize(u32, u32),
     /// Request current position via oneshot channel
     GetPosition(tokio::sync::oneshot::Sender<PositionEvent>),
+    /// Publish the current rendered pixels to the optional web overlay.
+    CaptureFrame,
     /// Run raid OCR.
     DetectRaidNames,
     /// Shutdown the overlay

--- a/app/src-tauri/src/stream_overlay.rs
+++ b/app/src-tauri/src/stream_overlay.rs
@@ -1,0 +1,391 @@
+//! Loopback-only web mirror for the native overlay windows.
+//!
+//! Native overlays already render their final pixels.  This module caches those
+//! small transparent frames and serves a tiny page that positions them at the
+//! same monitor-relative coordinates.  No combat or overlay UI logic is
+//! duplicated in the browser.
+
+use std::collections::HashMap;
+use std::io::Cursor;
+use std::net::{Ipv4Addr, SocketAddr};
+use std::sync::atomic::{AtomicBool, AtomicU64, Ordering};
+use std::sync::{Arc, Mutex, OnceLock};
+
+use baras_overlay::Overlay;
+use baras_types::{WEB_OVERLAY_PORT, WEB_OVERLAY_URL};
+use serde::Serialize;
+use tokio::io::{AsyncReadExt, AsyncWriteExt};
+use tokio::net::{TcpListener, TcpStream};
+use tokio::sync::{Mutex as AsyncMutex, oneshot};
+
+use crate::overlay::OverlayType;
+
+const OVERLAY_PAGE: &str = r#"<!doctype html>
+<html>
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width,initial-scale=1">
+  <title>Baras Web Overlay</title>
+  <style>
+    html, body, #scene {
+      margin: 0;
+      width: 100%;
+      height: 100%;
+      overflow: hidden;
+      background: transparent;
+    }
+    #scene { position: relative; }
+    .overlay {
+      position: absolute;
+      pointer-events: none;
+      user-select: none;
+    }
+  </style>
+</head>
+<body>
+  <div id="scene"></div>
+  <script>
+    const scene = document.getElementById('scene');
+    const overlays = new Map();
+
+    function clearScene() {
+      for (const image of overlays.values()) image.remove();
+      overlays.clear();
+    }
+
+    async function refresh() {
+      try {
+        const response = await fetch('/scene', { cache: 'no-store' });
+        if (!response.ok) throw new Error('Web overlay unavailable');
+        const frames = await response.json();
+        const active = new Set();
+
+        for (const frame of frames) {
+          active.add(frame.id);
+          let image = overlays.get(frame.id);
+          if (!image) {
+            image = document.createElement('img');
+            image.className = 'overlay';
+            image.alt = '';
+            image.draggable = false;
+            overlays.set(frame.id, image);
+            scene.appendChild(image);
+          }
+
+          image.style.left = `${frame.x}px`;
+          image.style.top = `${frame.y}px`;
+          image.style.width = `${frame.width}px`;
+          image.style.height = `${frame.height}px`;
+
+          const revision = String(frame.revision);
+          if (image.dataset.revision !== revision) {
+            image.dataset.revision = revision;
+            image.src = `/frame/${frame.id}.png?v=${revision}`;
+          }
+        }
+
+        for (const [id, image] of overlays) {
+          if (!active.has(id)) {
+            image.remove();
+            overlays.delete(id);
+          }
+        }
+      } catch (_) {
+        clearScene();
+      }
+
+      window.setTimeout(refresh, 100);
+    }
+
+    refresh();
+  </script>
+</body>
+</html>
+"#;
+
+static CAPTURE_ENABLED: AtomicBool = AtomicBool::new(false);
+static FRAME_SEQUENCE: AtomicU64 = AtomicU64::new(1);
+static FRAME_CACHE: OnceLock<Mutex<HashMap<String, CachedFrame>>> = OnceLock::new();
+
+fn frame_cache() -> &'static Mutex<HashMap<String, CachedFrame>> {
+    FRAME_CACHE.get_or_init(|| Mutex::new(HashMap::new()))
+}
+
+fn lock_frames() -> std::sync::MutexGuard<'static, HashMap<String, CachedFrame>> {
+    frame_cache()
+        .lock()
+        .unwrap_or_else(|poisoned| poisoned.into_inner())
+}
+
+struct CachedFrame {
+    x: i32,
+    y: i32,
+    width: u32,
+    height: u32,
+    revision: u64,
+    rgba: Vec<u8>,
+    png: Option<Vec<u8>>,
+}
+
+#[derive(Serialize)]
+struct SceneFrame {
+    id: String,
+    x: i32,
+    y: i32,
+    width: u32,
+    height: u32,
+    revision: u64,
+}
+
+/// Cache the pixels produced by a native overlay render.
+pub fn capture_overlay<O: Overlay>(kind: OverlayType, overlay: &mut O) {
+    if !CAPTURE_ENABLED.load(Ordering::Relaxed) {
+        return;
+    }
+
+    let position = overlay.position();
+    let (monitor_x, monitor_y) = overlay
+        .frame()
+        .window()
+        .current_monitor()
+        .map(|monitor| (monitor.x, monitor.y))
+        .unwrap_or((0, 0));
+
+    let Some(rgba) = overlay.frame_mut().window_mut().snapshot_rgba() else {
+        return;
+    };
+    if rgba.len() != (position.width * position.height * 4) as usize {
+        return;
+    }
+
+    let frame = CachedFrame {
+        x: position.x - monitor_x,
+        y: position.y - monitor_y,
+        width: position.width,
+        height: position.height,
+        revision: FRAME_SEQUENCE.fetch_add(1, Ordering::Relaxed),
+        rgba,
+        png: None,
+    };
+    lock_frames().insert(kind.config_key().to_string(), frame);
+}
+
+/// Remove an overlay as soon as its native window closes.
+pub fn remove_frame(kind: OverlayType) {
+    lock_frames().remove(kind.config_key());
+}
+
+fn clear_frames() {
+    lock_frames().clear();
+}
+
+fn scene_json() -> Vec<u8> {
+    let frames = lock_frames();
+    let mut scene: Vec<_> = frames
+        .iter()
+        .map(|(id, frame)| SceneFrame {
+            id: id.clone(),
+            x: frame.x,
+            y: frame.y,
+            width: frame.width,
+            height: frame.height,
+            revision: frame.revision,
+        })
+        .collect();
+    scene.sort_unstable_by(|a, b| a.id.cmp(&b.id));
+    serde_json::to_vec(&scene).unwrap_or_else(|_| b"[]".to_vec())
+}
+
+fn frame_png(id: &str) -> Option<Vec<u8>> {
+    let (revision, width, height, rgba) = {
+        let frames = lock_frames();
+        let frame = frames.get(id)?;
+        if let Some(png) = &frame.png {
+            return Some(png.clone());
+        }
+        (
+            frame.revision,
+            frame.width,
+            frame.height,
+            frame.rgba.clone(),
+        )
+    };
+
+    let png = encode_png(width, height, rgba).ok()?;
+    let mut frames = lock_frames();
+    if let Some(frame) = frames.get_mut(id)
+        && frame.revision == revision
+    {
+        frame.png = Some(png.clone());
+    }
+    Some(png)
+}
+
+/// tiny-skia stores premultiplied RGBA; PNG/browser input expects straight RGBA.
+fn encode_png(width: u32, height: u32, mut rgba: Vec<u8>) -> Result<Vec<u8>, String> {
+    for pixel in rgba.chunks_exact_mut(4) {
+        let alpha = pixel[3] as u32;
+        if alpha > 0 && alpha < 255 {
+            for channel in &mut pixel[..3] {
+                *channel = (((*channel as u32 * 255) + alpha / 2) / alpha).min(255) as u8;
+            }
+        }
+    }
+
+    let mut output = Vec::new();
+    {
+        let mut encoder = png::Encoder::new(Cursor::new(&mut output), width, height);
+        encoder.set_color(png::ColorType::Rgba);
+        encoder.set_depth(png::BitDepth::Eight);
+        let mut writer = encoder.write_header().map_err(|error| error.to_string())?;
+        writer
+            .write_image_data(&rgba)
+            .map_err(|error| error.to_string())?;
+    }
+    Ok(output)
+}
+
+struct RunningServer {
+    shutdown: oneshot::Sender<()>,
+    task: tokio::task::JoinHandle<()>,
+}
+
+#[derive(Clone, Default)]
+pub struct WebOverlayServer {
+    running: Arc<AsyncMutex<Option<RunningServer>>>,
+}
+
+impl WebOverlayServer {
+    pub async fn start(&self) -> Result<(), String> {
+        let mut running = self.running.lock().await;
+        if running.is_some() {
+            return Ok(());
+        }
+
+        let address = SocketAddr::from((Ipv4Addr::LOCALHOST, WEB_OVERLAY_PORT));
+        let listener = TcpListener::bind(address).await.map_err(|error| {
+            format!("Could not start web overlay on {WEB_OVERLAY_URL}: {error}")
+        })?;
+        let (shutdown_tx, shutdown_rx) = oneshot::channel();
+
+        CAPTURE_ENABLED.store(true, Ordering::Relaxed);
+        let task = tokio::spawn(run_server(listener, shutdown_rx));
+        *running = Some(RunningServer {
+            shutdown: shutdown_tx,
+            task,
+        });
+        tracing::info!(url = WEB_OVERLAY_URL, "Web overlay server started");
+        Ok(())
+    }
+
+    pub async fn stop(&self) {
+        let server = self.running.lock().await.take();
+        CAPTURE_ENABLED.store(false, Ordering::Relaxed);
+        clear_frames();
+
+        if let Some(server) = server {
+            let _ = server.shutdown.send(());
+            let _ = server.task.await;
+            tracing::info!("Web overlay server stopped");
+        }
+    }
+}
+
+async fn run_server(listener: TcpListener, mut shutdown: oneshot::Receiver<()>) {
+    loop {
+        tokio::select! {
+            _ = &mut shutdown => break,
+            accepted = listener.accept() => {
+                match accepted {
+                    Ok((stream, _)) => {
+                        tokio::spawn(async move {
+                            if let Err(error) = handle_connection(stream).await {
+                                tracing::debug!(error = %error, "Web overlay connection closed");
+                            }
+                        });
+                    }
+                    Err(error) => {
+                        tracing::warn!(error = %error, "Web overlay accept failed");
+                    }
+                }
+            }
+        }
+    }
+}
+
+async fn handle_connection(mut stream: TcpStream) -> std::io::Result<()> {
+    let mut request = [0_u8; 4096];
+    let read = stream.read(&mut request).await?;
+    if read == 0 {
+        return Ok(());
+    }
+
+    let request = String::from_utf8_lossy(&request[..read]);
+    let mut request_parts = request
+        .lines()
+        .next()
+        .unwrap_or_default()
+        .split_whitespace();
+    let method = request_parts.next().unwrap_or_default();
+    let target = request_parts.next().unwrap_or_default();
+    let path = target.split('?').next().unwrap_or(target);
+
+    let (status, content_type, body) = if method != "GET" {
+        (
+            "405 Method Not Allowed",
+            "text/plain; charset=utf-8",
+            b"Method not allowed".to_vec(),
+        )
+    } else if matches!(path, "/" | "/overlay" | "/overlay/") {
+        (
+            "200 OK",
+            "text/html; charset=utf-8",
+            OVERLAY_PAGE.as_bytes().to_vec(),
+        )
+    } else if path == "/scene" {
+        ("200 OK", "application/json", scene_json())
+    } else if let Some(id) = path
+        .strip_prefix("/frame/")
+        .and_then(|value| value.strip_suffix(".png"))
+    {
+        match frame_png(id) {
+            Some(png) => ("200 OK", "image/png", png),
+            None => (
+                "404 Not Found",
+                "text/plain; charset=utf-8",
+                b"Frame not found".to_vec(),
+            ),
+        }
+    } else {
+        (
+            "404 Not Found",
+            "text/plain; charset=utf-8",
+            b"Not found".to_vec(),
+        )
+    };
+
+    let headers = format!(
+        "HTTP/1.1 {status}\r\nContent-Type: {content_type}\r\nContent-Length: {}\r\nCache-Control: no-store\r\nX-Content-Type-Options: nosniff\r\nConnection: close\r\n\r\n",
+        body.len()
+    );
+    stream.write_all(headers.as_bytes()).await?;
+    stream.write_all(&body).await?;
+    stream.shutdown().await
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn png_encoder_preserves_transparency() {
+        let png = encode_png(1, 1, vec![0, 0, 0, 0]).expect("PNG should encode");
+        assert_eq!(&png[..8], b"\x89PNG\r\n\x1a\n");
+    }
+
+    #[test]
+    fn overlay_page_is_transparent() {
+        assert!(OVERLAY_PAGE.contains("background: transparent"));
+        assert!(OVERLAY_PAGE.contains("fetch('/scene'"));
+    }
+}

--- a/app/src-tauri/src/stream_overlay.rs
+++ b/app/src-tauri/src/stream_overlay.rs
@@ -94,7 +94,7 @@ const OVERLAY_PAGE: &str = r#"<!doctype html>
         clearScene();
       }
 
-      window.requestAnimationFrame(refresh);
+      window.setTimeout(refresh, 100);
     }
 
     refresh();
@@ -387,6 +387,5 @@ mod tests {
     fn overlay_page_is_transparent() {
         assert!(OVERLAY_PAGE.contains("background: transparent"));
         assert!(OVERLAY_PAGE.contains("fetch('/scene'"));
-        assert!(OVERLAY_PAGE.contains("requestAnimationFrame(refresh)"));
     }
 }

--- a/app/src-tauri/src/stream_overlay.rs
+++ b/app/src-tauri/src/stream_overlay.rs
@@ -94,7 +94,7 @@ const OVERLAY_PAGE: &str = r#"<!doctype html>
         clearScene();
       }
 
-      window.setTimeout(refresh, 100);
+      window.requestAnimationFrame(refresh);
     }
 
     refresh();
@@ -387,5 +387,6 @@ mod tests {
     fn overlay_page_is_transparent() {
         assert!(OVERLAY_PAGE.contains("background: transparent"));
         assert!(OVERLAY_PAGE.contains("fetch('/scene'"));
+        assert!(OVERLAY_PAGE.contains("requestAnimationFrame(refresh)"));
     }
 }

--- a/app/src/api.rs
+++ b/app/src/api.rs
@@ -98,6 +98,12 @@ pub async fn update_config(config: &AppConfig) -> Result<(), String> {
     Ok(())
 }
 
+/// Start or stop the loopback web overlay and persist the setting.
+pub async fn set_web_overlay_enabled(enabled: bool) -> Result<(), String> {
+    try_invoke("set_web_overlay_enabled", build_args("enabled", &enabled)).await?;
+    Ok(())
+}
+
 /// Whether the app is running in a Wayland session
 pub async fn is_wayland_session() -> bool {
     let result = invoke("is_wayland_session", JsValue::NULL).await;

--- a/app/src/app.rs
+++ b/app/src/app.rs
@@ -14,7 +14,7 @@ use crate::components::{
 use crate::components::class_icons::{get_class_icon, get_role_icon};
 use crate::types::{
     AreaVisitInfo, LogFileInfo, MainTab, MetricType, OverlaySettings, OverlayStatus, OverlayType,
-    SessionInfo, UiSessionState, UpdateInfo,
+    SessionInfo, UiSessionState, UpdateInfo, WEB_OVERLAY_URL,
 };
 
 static CSS: Asset = asset!("/assets/styles.css");
@@ -140,6 +140,7 @@ pub fn App() -> Element {
 
     // Application settings
     let mut minimize_to_tray = use_signal(|| true);
+    let mut web_overlay_enabled = use_signal(|| false);
     let mut european_number_format = use_signal(|| false);
     let mut app_version = use_signal(String::new);
 
@@ -213,6 +214,7 @@ pub fn App() -> Element {
             ocr_debug_dump.set(config.ocr_debug_dump);
             ocr_debug_max_dumps.set(config.ocr_debug_max_dumps);
             minimize_to_tray.set(config.minimize_to_tray);
+            web_overlay_enabled.set(config.web_overlay_enabled);
             european_number_format.set(config.european_number_format);
             parsely_username.set(config.parsely.username);
             parsely_password.set(config.parsely.password);
@@ -2072,6 +2074,29 @@ pub fn App() -> Element {
                                     }
                                 }
                                 p { class: "hint", "When enabled, closing the window hides to system tray instead of quitting." }
+                                div { class: "setting-row",
+                                    label { "Web overlay" }
+                                    input {
+                                        r#type: "checkbox",
+                                        checked: web_overlay_enabled(),
+                                        onchange: move |e| {
+                                            let checked = e.checked();
+                                            let previous = web_overlay_enabled();
+                                            web_overlay_enabled.set(checked);
+                                            let mut toast = use_toast();
+                                            spawn(async move {
+                                                if let Err(err) = api::set_web_overlay_enabled(checked).await {
+                                                    web_overlay_enabled.set(previous);
+                                                    toast.show(format!("Failed to change web overlay: {}", err), ToastSeverity::Normal);
+                                                }
+                                            });
+                                        }
+                                    }
+                                }
+                                p { class: "hint", "Mirror the Baras overlays currently shown into any streaming software with a browser source." }
+                                if web_overlay_enabled() {
+                                    code { class: "web-overlay-url", "{WEB_OVERLAY_URL}" }
+                                }
                                 div { class: "setting-row",
                                     label { "European number format" }
                                     input {

--- a/app/src/types.rs
+++ b/app/src/types.rs
@@ -64,6 +64,7 @@ pub use baras_types::{
     UsageSortColumn,
     ViewMode,
     MAX_PROFILES,
+    WEB_OVERLAY_URL,
 };
 
 // Type alias for context-specific trigger usage

--- a/overlay/src/manager.rs
+++ b/overlay/src/manager.rs
@@ -314,6 +314,11 @@ impl OverlayWindow {
         self.platform.commit();
     }
 
+    /// Copy the final premultiplied RGBA pixels for non-window consumers.
+    pub fn snapshot_rgba(&mut self) -> Option<Vec<u8>> {
+        self.platform.pixel_buffer().map(|pixels| pixels.to_vec())
+    }
+
     /// Poll for events (non-blocking)
     /// Returns false if the window should close
     pub fn poll_events(&mut self) -> bool {

--- a/types/src/lib.rs
+++ b/types/src/lib.rs
@@ -3328,8 +3328,10 @@ impl ParselySettings {
 /// Note: Persistence methods (load/save) are provided by baras-core via the
 /// `AppConfigExt` trait, as they require platform-specific dependencies.
 /// The frontend derives Default (getting empty values) which is fine for deserialization.
-pub const WEB_OVERLAY_PORT: u16 = 49684;
-pub const WEB_OVERLAY_URL: &str = "http://127.0.0.1:49684/overlay";
+// Keep the fixed browser-source URL below Windows' default TCP range
+// (49152-65535), where outbound connections can otherwise claim the port.
+pub const WEB_OVERLAY_PORT: u16 = 47684;
+pub const WEB_OVERLAY_URL: &str = "http://127.0.0.1:47684/overlay";
 
 #[derive(Debug, Clone, Default, Serialize, Deserialize)]
 pub struct AppConfig {

--- a/types/src/lib.rs
+++ b/types/src/lib.rs
@@ -3328,6 +3328,9 @@ impl ParselySettings {
 /// Note: Persistence methods (load/save) are provided by baras-core via the
 /// `AppConfigExt` trait, as they require platform-specific dependencies.
 /// The frontend derives Default (getting empty values) which is fine for deserialization.
+pub const WEB_OVERLAY_PORT: u16 = 49684;
+pub const WEB_OVERLAY_URL: &str = "http://127.0.0.1:49684/overlay";
+
 #[derive(Debug, Clone, Default, Serialize, Deserialize)]
 pub struct AppConfig {
     #[serde(default)]
@@ -3342,6 +3345,9 @@ pub struct AppConfig {
     pub log_retention_days: u32,
     #[serde(default = "default_true")]
     pub minimize_to_tray: bool,
+    /// Serve the currently visible native overlays on a loopback-only web page.
+    #[serde(default)]
+    pub web_overlay_enabled: bool,
     #[serde(default)]
     pub overlay_settings: OverlaySettings,
     #[serde(default)]
@@ -3433,6 +3439,7 @@ impl AppConfig {
             auto_delete_old_files: false,
             log_retention_days: 21,
             minimize_to_tray: false,
+            web_overlay_enabled: false,
             overlay_settings: OverlaySettings::default(),
             hotkeys: HotkeySettings::default(),
             profiles: Vec::new(),


### PR DESCRIPTION
I added a toggle in the main Baras settings that starts a small localhost web server at http://127.0.0.1:47684/overlay. It hooks into the existing native overlay render loop and copies the final rendered pixels, so there is no duplicate parsing or overlay logic. The webpage checks for updates every 100ms and places all enabled/shown overlays at the same positions with a transparent background, so they can be used as a source in for instance OBS.